### PR TITLE
Add filters to adjust expiration time dynamically

### DIFF
--- a/includes/class-woocommerce-cart-stock-reducer.php
+++ b/includes/class-woocommerce-cart-stock-reducer.php
@@ -515,8 +515,9 @@ class WC_Cart_Stock_Reducer extends WC_Integration {
 						$expire_time_text = $item_expire_time;
 					}
 				}
+				$expire_time_text = apply_filters( 'wc_csr_expire_time_text', $expire_time_text, $item, $key, $this );
 				if ( null !== $expire_time_text && 'never' !== $expire_time_text ) {
-					$item[ 'csr_expire_time' ] = strtotime( $expire_time_text );
+					$item[ 'csr_expire_time' ] = apply_filters( 'wc_csr_expire_time', strtotime( $expire_time_text ), $expire_time_text, $item, $key, $this );
 					$item[ 'csr_expire_time_text' ] = $expire_time_text;
 				}
 			}


### PR DESCRIPTION
Most likely to be used is 'wc_csr_expire_time_text' which adjusts the text string (ie: '5 Minutes').  This happens early enough that a specific item could be set to 'never' in case you don't want it
to expire or you could check if the user is logged in and force a specific expiration for those users.

The other filter is 'wc_csr_expire_time' which is used to adjust the number of seconds since the epoch for an item that will expire.  This is probably most useful if you want to do some kind of math
on the number rather than using plain english.  This happens after the 'never' check so if an item is set not to expire this filter will not be called

Fixes #51