### PR TITLE
add support for composite and bundle products

### DIFF
--- a/includes/class-woocommerce-cart-stock-reducer.php
+++ b/includes/class-woocommerce-cart-stock-reducer.php
@@ -308,11 +308,11 @@ class WC_Cart_Stock_Reducer extends WC_Integration {
 		if ( 'yes' === $this->expire_items ) {
 			// remove whole container, not only one product inside
 			$container = false;
-			if( function_exists('wc_pb_get_bundled_cart_item_container')){
+			if ( function_exists('wc_pb_get_bundled_cart_item_container') ) {
 				$container = wc_pb_get_bundled_cart_item_container( $cart->cart_contents[ $cart_id ], $cart->cart_contents, true );
 			}
 			// check composite after bundle, since it could include the bundle
-			if( function_exists('wc_cp_get_composited_cart_item_container')){
+			if ( function_exists('wc_cp_get_composited_cart_item_container') ) {
 				$container_id = $container ? $cart->cart_contents[ $container ] : $cart->cart_contents[ $cart_id ];
 				$composite = wc_cp_get_composited_cart_item_container( $container_id, $cart->cart_contents, true ); 
 				$container = $composite ? $composite : $container;

--- a/includes/class-woocommerce-cart-stock-reducer.php
+++ b/includes/class-woocommerce-cart-stock-reducer.php
@@ -306,9 +306,6 @@ class WC_Cart_Stock_Reducer extends WC_Integration {
 			return;
 		}
 		if ( 'yes' === $this->expire_items ) {
-			/*-----------------------------------------*/
-			/* BEGIN NEW CODE						   */
-			/*-----------------------------------------*/
 			// remove whole container, not only one product inside
 			$container = false;
 			if( function_exists('wc_pb_get_bundled_cart_item_container')){
@@ -336,9 +333,6 @@ class WC_Cart_Stock_Reducer extends WC_Integration {
 				$item_description = $cart->cart_contents[ $cart_id ][ 'data' ]->get_title();
 				$product = wc_get_product( $cart->cart_contents[ $cart_id ][ 'product_id' ] );
 			}
-			/*-----------------------------------------*/
-			/* END NEW CODE							   */
-			/*-----------------------------------------*/
 			// Include link to item removed during notice
 			$item_description = '<a href="' . esc_url( $product->get_permalink() ) . '">' . $item_description . '</a>';
 			$expired_cart_notice = apply_filters( 'wc_csr_expired_cart_notice', sprintf( __( "Sorry, '%s' was removed from your cart because you didn't checkout before the expiration time.", 'woocommerce-cart-stock-reducer' ), $item_description ), $cart_id, $cart );

--- a/includes/class-woocommerce-cart-stock-reducer.php
+++ b/includes/class-woocommerce-cart-stock-reducer.php
@@ -318,7 +318,12 @@ class WC_Cart_Stock_Reducer extends WC_Integration {
 				$container = $composite ? $composite : $container;
 			}
 
-			if ( $container === false ) {
+			if ( $container !== false ) {
+				// Product is in container/composite
+				$cart_id = $container;
+				$item_description = $cart->cart_contents[ $cart_id ][ 'data' ]->get_title();
+				$product = wc_get_product( $cart->cart_contents[ $cart_id ][ 'product_id' ] );
+			} else {
 				$item_description = $cart->cart_contents[ $cart_id ][ 'data' ]->get_title();
 				if ( !empty( $cart->cart_contents[ $cart_id ][ 'variation_id' ] ) ) {
 					$product = wc_get_product( $cart->cart_contents[ $cart_id ][ 'variation_id' ] );
@@ -328,10 +333,6 @@ class WC_Cart_Stock_Reducer extends WC_Integration {
 				} else {
 					$product = wc_get_product( $cart->cart_contents[ $cart_id ][ 'product_id' ] );
 				}
-			} else {
-				$cart_id = $container;
-				$item_description = $cart->cart_contents[ $cart_id ][ 'data' ]->get_title();
-				$product = wc_get_product( $cart->cart_contents[ $cart_id ][ 'product_id' ] );
 			}
 			// Include link to item removed during notice
 			$item_description = '<a href="' . esc_url( $product->get_permalink() ) . '">' . $item_description . '</a>';


### PR DESCRIPTION
Hi there,
I added some lines of code to verify if the cart item is a [bundle](https://woocommerce.com/products/product-bundles/) or a [composite product](https://woocommerce.com/products/composite-products/) and to then remove this product container with all its children. This would bring support for the two widely used, official WooCommerce plugins. 

Currently, if one is using these plugins, only the children are removed, with the container still laying in the cart. 

If needed, I'm happy to provide you with current versions of the plugin (for testing only that is).

Best

Jan